### PR TITLE
fix(deploy): add `"jsxImportSource": "react"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ deno install -Arfg jsr:@deno/deployctl
 deployctl upgrade
 ```
 
+7. If you haven't already, run the `build` task to create production build:
+
+```sh
+deno task build
+```
+
 ### Deploying to Deno Deploy
 
 After you've set up Deno Deploy, run:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,11 +8,18 @@
     "app/**/.client/**/*.tsx"
   ],
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2022"],
-    "types": ["vite/client"],
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ES2022"
+    ],
+    "types": [
+      "vite/client"
+    ],
     "isolatedModules": true,
     "esModuleInterop": true,
     "jsx": "react-jsx",
+    "jsxImportSource": "react",
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,
@@ -24,9 +31,10 @@
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
     "paths": {
-      "~/*": ["./app/*"]
+      "~/*": [
+        "./app/*"
+      ]
     },
-
     // Vite takes care of building everything, not tsc.
     "noEmit": true
   }


### PR DESCRIPTION
This fix resolves an issue I saw when deploying via Deno Deploy.

Error:
```sh
✖ Upload failed.
error: The deployment failed: Compiler option 'jsx' set to 'react-jsx', but no 'jsxImportSource' defined.
```

Fix:
Adds `"jsxImportSource": "react",` to `deno.json -> compilerOptions`

This also prompts the developer to run `deno task build` before deploy if they haven't already to prevent the following error:

```sh
✖ Deployment failed.
error: The deployment failed: UNCAUGHT_EXCEPTION

TypeError: No such file or directory (os error 2)
    at async file:///src/server.production.ts:7:3
```